### PR TITLE
Feature/custom checker

### DIFF
--- a/src/main/channels.js
+++ b/src/main/channels.js
@@ -10,7 +10,7 @@ const CHANNELS = {
 
   SET_TIME_LIMIT: 'renderer-set-time-limit',
 
-  SET_CHECKER: 'renderer-set-checker',
+  SET_CHECKER_TYPE: 'renderer-set-checker-type',
   SET_EPSILON: 'renderer-set-epsilon',
 
   JUDGE: 'renderer-judge',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -22,7 +22,7 @@ import {
   judge,
   setTimeLimit,
   openCaseInfo,
-  setChecker,
+  setCheckerType,
   setEpsilon,
 } from './runner/judge';
 import { clearCache, touchCache } from './utils';
@@ -42,7 +42,7 @@ let mainWindow: BrowserWindow | null = null;
 ipcMain.on(CHANNELS.CHECK_DEPS, checkDeps);
 ipcMain.on(CHANNELS.SELECT_FILE, selectFile);
 ipcMain.on(CHANNELS.SET_TIME_LIMIT, setTimeLimit);
-ipcMain.on(CHANNELS.SET_CHECKER, setChecker);
+ipcMain.on(CHANNELS.SET_CHECKER_TYPE, setCheckerType);
 ipcMain.on(CHANNELS.SET_EPSILON, setEpsilon);
 ipcMain.on(CHANNELS.JUDGE, judge);
 ipcMain.on(CHANNELS.OPEN_CASE_INFO, openCaseInfo);

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -16,8 +16,8 @@ contextBridge.exposeInMainWorld('electron', {
     setTimeLimit(limit) {
       ipcRenderer.send(CHANNELS.SET_TIME_LIMIT, limit);
     },
-    setChecker(checker) {
-      ipcRenderer.send(CHANNELS.SET_CHECKER, checker);
+    setCheckerType(checkerType) {
+      ipcRenderer.send(CHANNELS.SET_CHECKER_TYPE, checkerType);
     },
     setEpsilon(epsilon) {
       ipcRenderer.send(CHANNELS.SET_EPSILON, epsilon);

--- a/src/main/runner/fastJudge.cpp
+++ b/src/main/runner/fastJudge.cpp
@@ -59,10 +59,10 @@ string stringVecToJSON(vector<string> &vec) {
     return ret;
 }
 
-const int NUM_ARGS = 12;
+const int NUM_ARGS = 13;
 int main(int argc, char **argv) {
     if (argc - 1 < NUM_ARGS) {
-        cout << "Usage: judge cachePath binaryName binaryPath lang [inputIDs,...] [inputPaths,...] [outputPaths,...] timeLimit directoryPathSeparator runScriptBinaryPath checker epsilon\n";
+        cout << "Usage: judge cachePath binaryName binaryPath lang [inputIDs,...] [inputPaths,...] [outputPaths,...] timeLimit directoryPathSeparator runScriptBinaryPath checker epsilon customCheckerPath\n";
         return 1;
     }
 
@@ -79,6 +79,7 @@ int main(int argc, char **argv) {
     string runScriptBinaryPath(argv[10]);
     string checker(argv[11]);
     string epsilon(argv[12]);
+    string customCheckerPath(argv[13]);
 
     // Judge each case.
     for (int testCase = 0; testCase < inputIDs.size(); testCase++) {
@@ -152,11 +153,13 @@ int main(int argc, char **argv) {
                 apolloLaunch += " -t";
             else if (checker == "epsilon")
                 apolloLaunch += " -e " + epsilon;
+            else if (checker == "custom")
+                apolloLaunch += " -c " + customCheckerPath;
 
             string check = apolloLaunch + " " +
                 inputPath + " " +
-                outputPath + " " +
-                userOutputPath;
+                userOutputPath + " " +
+                outputPath;
 
             FILE *checkOutput = popen(check.c_str(), "r");
 

--- a/src/main/runner/judge.ts
+++ b/src/main/runner/judge.ts
@@ -14,6 +14,18 @@ import {
 import CHANNELS from '../channels';
 import compile from './compile';
 
+const STORE_KEYS = {
+  SOURCE: 'source',
+  DATA: 'data',
+  TIME_LIMIT: 'time-limit',
+  CHECKER_TYPE: 'checker-type',
+  EPSILON: 'epsilon',
+};
+
+const getDataLocationStoreKey = (caseID: string) => {
+  return `casePaths.${caseID}`;
+};
+
 // Store for the main thread. Get rid of old data
 const store = new Store();
 store.clear();
@@ -43,16 +55,16 @@ export const setTimeLimit = async (
   _event: Electron.IpcMainEvent,
   limit: number
 ) => {
-  store.set('timeLimit', limit);
+  store.set(STORE_KEYS.TIME_LIMIT, limit);
 };
 
 // Set the checker in the store
-type CheckerType = 'diff' | 'token' | 'epsilon';
-export const setChecker = async (
+type CheckerTypeType = 'diff' | 'token' | 'epsilon';
+export const setCheckerType = async (
   _event: Electron.IpcMainEvent,
-  checker: CheckerType
+  checkerType: CheckerTypeType
 ) => {
-  store.set('checker', checker);
+  store.set(STORE_KEYS.CHECKER_TYPE, checkerType);
 };
 
 // Set the epsilon in the store
@@ -60,7 +72,7 @@ export const setEpsilon = async (
   _event: Electron.IpcMainEvent,
   epsilon: number
 ) => {
-  store.set('epsilon', epsilon);
+  store.set(STORE_KEYS.EPSILON, epsilon);
 };
 
 // Attempt to open the requested info about a case
@@ -70,7 +82,9 @@ export const openCaseInfo = async (
   caseID: string,
   infoType: InfoType
 ) => {
-  const dataLocation: string = store.get(`casePaths.${caseID}`) as string;
+  const dataLocation: string = store.get(
+    getDataLocationStoreKey(caseID)
+  ) as string;
   // Get a path to what we are trying to open
   let absPath = '';
   switch (infoType) {
@@ -105,11 +119,11 @@ export const judge = async (event: Electron.IpcMainEvent) => {
    */
   event.reply(CHANNELS.BEGIN_COLLECT_DATA);
 
-  const source = store.get('source', null) as string | null;
-  const data = store.get('data', null) as string | null;
-  const timeLimit = store.get('timeLimit', 1) as number;
-  const checker = store.get('checker', 'diff') as string;
-  const epsilon = store.get('epsilon', 0.0000001) as number;
+  const source = store.get(STORE_KEYS.SOURCE, null) as string | null;
+  const data = store.get(STORE_KEYS.DATA, null) as string | null;
+  const timeLimit = store.get(STORE_KEYS.TIME_LIMIT, 1) as number;
+  const checker = store.get(STORE_KEYS.CHECKER_TYPE, 'diff') as string;
+  const epsilon = store.get(STORE_KEYS.EPSILON, 0.0000001) as number;
 
   if (source == null || data == null) {
     event.reply(CHANNELS.MISSING_INFO);
@@ -135,7 +149,7 @@ export const judge = async (event: Electron.IpcMainEvent) => {
 
   const inputIds = inputs.map((absPath) => {
     const caseID = getFileNameFromPath(absPath);
-    store.set(`casePaths.${caseID}`, path.dirname(absPath));
+    store.set(getDataLocationStoreKey(caseID), path.dirname(absPath));
     return caseID;
   });
 

--- a/src/renderer/components/CheckerTypeSelectorRow.tsx
+++ b/src/renderer/components/CheckerTypeSelectorRow.tsx
@@ -1,28 +1,45 @@
 import { Space } from 'antd';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import CHANNELS from '../utils/channels';
 import eventHandler from '../utils/eventHandler';
 import { CheckerTypeType } from '../utils/Types';
 import DropdownSelectorRow from './DropdownSelectorRow';
+import FileSelectionRow from './FileSelectionRow';
 import NumberSelectionRow from './NumberSelectionRow';
 
 const CHECKER_TYPE_OPTIONS: Array<CheckerTypeType> = [
   'diff',
   'token',
   'epsilon',
+  'custom',
 ];
 
 const CheckerTypeSelectorRow = () => {
   const [checkerType, setCheckerType] = useState<CheckerTypeType>(
     CHECKER_TYPE_OPTIONS[0]
   );
+  const [checkerBinaryPath, setCheckerBinaryPath] = useState<
+    string | undefined
+  >();
+
+  const updateCheckerBinaryPath = (key: string, newPath: string) => {
+    if (key === 'custom-checker-path') setCheckerBinaryPath(newPath);
+  };
+
+  useEffect(() => {
+    const remover = eventHandler.on(
+      CHANNELS.FILE_SELECTED,
+      updateCheckerBinaryPath
+    );
+
+    return () => {
+      remover();
+    };
+  }, []);
 
   const onChangeCheckerType = (newCheckerType: CheckerTypeType) => {
     setCheckerType(newCheckerType);
     eventHandler.setCheckerType(newCheckerType);
-  };
-
-  const onChangeEpsilon = (newEpsilon: number) => {
-    eventHandler.setEpsilon(newEpsilon);
   };
 
   const getCheckerMetaComponent = () => {
@@ -32,8 +49,19 @@ const CheckerTypeSelectorRow = () => {
           label="Epsilon"
           type="float"
           min={0}
+          max={999999}
           defaultValue={0.000001}
-          onChange={onChangeEpsilon}
+          onChange={(newEps: number) => eventHandler.setEpsilon(newEps)}
+        />
+      );
+
+    if (checkerType === 'custom')
+      return (
+        <FileSelectionRow
+          label="Checker Binary"
+          placeholder="Select file"
+          value={checkerBinaryPath}
+          onClick={() => eventHandler.setFile('custom-checker-path', false)}
         />
       );
 

--- a/src/renderer/components/CheckerTypeSelectorRow.tsx
+++ b/src/renderer/components/CheckerTypeSelectorRow.tsx
@@ -1,0 +1,57 @@
+import { Space } from 'antd';
+import { useState } from 'react';
+import eventHandler from '../utils/eventHandler';
+import { CheckerTypeType } from '../utils/Types';
+import DropdownSelectorRow from './DropdownSelectorRow';
+import NumberSelectionRow from './NumberSelectionRow';
+
+const CHECKER_TYPE_OPTIONS: Array<CheckerTypeType> = [
+  'diff',
+  'token',
+  'epsilon',
+];
+
+const CheckerTypeSelectorRow = () => {
+  const [checkerType, setCheckerType] = useState<CheckerTypeType>(
+    CHECKER_TYPE_OPTIONS[0]
+  );
+
+  const onChangeCheckerType = (newCheckerType: CheckerTypeType) => {
+    setCheckerType(newCheckerType);
+    eventHandler.setCheckerType(newCheckerType);
+  };
+
+  const onChangeEpsilon = (newEpsilon: number) => {
+    eventHandler.setEpsilon(newEpsilon);
+  };
+
+  const getCheckerMetaComponent = () => {
+    if (checkerType === 'epsilon')
+      return (
+        <NumberSelectionRow
+          label="Epsilon"
+          type="float"
+          min={0}
+          defaultValue={0.000001}
+          onChange={onChangeEpsilon}
+        />
+      );
+
+    return null;
+  };
+
+  return (
+    <Space direction="vertical" style={{ width: '100%' }}>
+      <DropdownSelectorRow
+        label="Checker"
+        choices={CHECKER_TYPE_OPTIONS}
+        onSelect={(value: string) =>
+          onChangeCheckerType(value as CheckerTypeType)
+        }
+      />
+      {getCheckerMetaComponent()}
+    </Space>
+  );
+};
+
+export default CheckerTypeSelectorRow;

--- a/src/renderer/pages/App.tsx
+++ b/src/renderer/pages/App.tsx
@@ -2,7 +2,12 @@ import { MemoryRouter as Router, Switch, Route } from 'react-router-dom';
 import DependencyCheck from './DependencyCheck';
 import Home from './Home';
 import './App.css';
-import { CheckerType, DepType, InfoType, InstallType } from '../utils/Types';
+import {
+  CheckerTypeType,
+  DepType,
+  InfoType,
+  InstallType,
+} from '../utils/Types';
 
 declare global {
   interface Window {
@@ -18,7 +23,7 @@ declare global {
         ) => void;
         setFile: (key: string, isDirectory: boolean) => void;
         setTimeLimit: (limit: number) => void;
-        setChecker: (checker: CheckerType) => void;
+        setCheckerType: (checkerType: CheckerTypeType) => void;
         setEpsilon: (epsilon: number) => void;
         judge: () => void;
         openCaseInfo: (caseID: string, infoType: InfoType) => void;

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import { Space } from 'antd';
 import CHANNELS from '../utils/channels';
 import eventHandler from '../utils/eventHandler';
-import { FileKeyType, CheckerTypeType } from '../utils/Types';
+import { FileKeyType } from '../utils/Types';
 import FileSelectionRow from '../components/FileSelectionRow';
 import NumberSelectionRow from '../components/NumberSelectionRow';
 import JudgeButton from '../components/JudgeButton';
 import Results from '../components/Results';
-import DropdownSelectorRow from '../components/DropdownSelectorRow';
+import CheckerTypeSelectorRow from '../components/CheckerTypeSelectorRow';
 
 type FileData = {
   [K in FileKeyType]?: string;
@@ -20,17 +20,8 @@ const FILE_KEYS = {
   OUTPUT: 'output',
 };
 
-const CHECKER_TYPE_OPTIONS: Array<CheckerTypeType> = [
-  'diff',
-  'token',
-  'epsilon',
-];
-
 export default function Home() {
   const [fileInfo, setFileInfo] = useState<FileData>({});
-  const [checkerType, setCheckerType] = useState<CheckerTypeType>(
-    CHECKER_TYPE_OPTIONS[0]
-  );
 
   // This is ok because the setter is only called as a LISTENER
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -52,15 +43,6 @@ export default function Home() {
 
   const onChangeTimeLimit = (limit: number) => {
     eventHandler.setTimeLimit(limit);
-  };
-
-  const onChangeCheckerType = (newCheckerType: CheckerTypeType) => {
-    setCheckerType(newCheckerType);
-    eventHandler.setCheckerType(newCheckerType);
-  };
-
-  const onChangeEpsilon = (newEpsilon: number) => {
-    eventHandler.setEpsilon(newEpsilon);
   };
 
   return (
@@ -92,22 +74,7 @@ export default function Home() {
           units="seconds"
           onChange={onChangeTimeLimit}
         />
-        <DropdownSelectorRow
-          label="Checker"
-          choices={CHECKER_TYPE_OPTIONS}
-          onSelect={(value: string) =>
-            onChangeCheckerType(value as CheckerTypeType)
-          }
-        />
-        {checkerType === 'epsilon' ? (
-          <NumberSelectionRow
-            label="Epsilon"
-            type="float"
-            min={0}
-            defaultValue={0.000001}
-            onChange={onChangeEpsilon}
-          />
-        ) : null}
+        <CheckerTypeSelectorRow />
         <JudgeButton />
         <Results />
       </Space>

--- a/src/renderer/pages/Home.tsx
+++ b/src/renderer/pages/Home.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Space } from 'antd';
 import CHANNELS from '../utils/channels';
 import eventHandler from '../utils/eventHandler';
-import { FileKeyType, CheckerType } from '../utils/Types';
+import { FileKeyType, CheckerTypeType } from '../utils/Types';
 import FileSelectionRow from '../components/FileSelectionRow';
 import NumberSelectionRow from '../components/NumberSelectionRow';
 import JudgeButton from '../components/JudgeButton';
@@ -20,11 +20,17 @@ const FILE_KEYS = {
   OUTPUT: 'output',
 };
 
-const CHECKER_OPTIONS: Array<CheckerType> = ['diff', 'token', 'epsilon'];
+const CHECKER_TYPE_OPTIONS: Array<CheckerTypeType> = [
+  'diff',
+  'token',
+  'epsilon',
+];
 
 export default function Home() {
   const [fileInfo, setFileInfo] = useState<FileData>({});
-  const [checker, setChecker] = useState<CheckerType>(CHECKER_OPTIONS[0]);
+  const [checkerType, setCheckerType] = useState<CheckerTypeType>(
+    CHECKER_TYPE_OPTIONS[0]
+  );
 
   // This is ok because the setter is only called as a LISTENER
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -48,9 +54,9 @@ export default function Home() {
     eventHandler.setTimeLimit(limit);
   };
 
-  const onChangeChecker = (newChecker: CheckerType) => {
-    setChecker(newChecker);
-    eventHandler.setChecker(newChecker);
+  const onChangeCheckerType = (newCheckerType: CheckerTypeType) => {
+    setCheckerType(newCheckerType);
+    eventHandler.setCheckerType(newCheckerType);
   };
 
   const onChangeEpsilon = (newEpsilon: number) => {
@@ -88,10 +94,12 @@ export default function Home() {
         />
         <DropdownSelectorRow
           label="Checker"
-          choices={CHECKER_OPTIONS}
-          onSelect={(value: string) => onChangeChecker(value as CheckerType)}
+          choices={CHECKER_TYPE_OPTIONS}
+          onSelect={(value: string) =>
+            onChangeCheckerType(value as CheckerTypeType)
+          }
         />
-        {checker === 'epsilon' ? (
+        {checkerType === 'epsilon' ? (
           <NumberSelectionRow
             label="Epsilon"
             type="float"

--- a/src/renderer/utils/Types.tsx
+++ b/src/renderer/utils/Types.tsx
@@ -12,6 +12,6 @@ export type Response = {
   messages: Array<string>;
 };
 export type InfoType = 'input' | 'output' | 'userOutput';
-export type CheckerTypeType = 'diff' | 'token' | 'epsilon';
+export type CheckerTypeType = 'diff' | 'token' | 'epsilon' | 'custom';
 export type DepType = 'Python 3' | 'Apollo' | 'xdg-open-wsl' | 'wsl';
 export type InstallType = 'pip';

--- a/src/renderer/utils/Types.tsx
+++ b/src/renderer/utils/Types.tsx
@@ -12,6 +12,6 @@ export type Response = {
   messages: Array<string>;
 };
 export type InfoType = 'input' | 'output' | 'userOutput';
-export type CheckerType = 'diff' | 'token' | 'epsilon';
+export type CheckerTypeType = 'diff' | 'token' | 'epsilon';
 export type DepType = 'Python 3' | 'Apollo' | 'xdg-open-wsl' | 'wsl';
 export type InstallType = 'pip';


### PR DESCRIPTION
Users can now supply a path to a custom checker binary. Note that Apollo does not yet support interpreted checkers (python).