### PR TITLE
Bugfix/xdg open on ptl

### DIFF
--- a/src/main/osSpecific.tsx
+++ b/src/main/osSpecific.tsx
@@ -35,3 +35,13 @@ export const maybeWslifyPath = async (absPath: string) => {
     });
   });
 };
+
+// Return an option based on what operating system class we are on
+export type PlatformType = 'linux' | 'mac';
+export type PlatformOptionsType = {
+  [P in PlatformType]: unknown;
+};
+export const platformSpecific = (options: PlatformOptionsType) => {
+  if (process.platform === 'darwin') return options.mac;
+  return options.linux;
+};

--- a/src/main/runner/fastCustomInvocation.cpp
+++ b/src/main/runner/fastCustomInvocation.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv) {
     ofstream out(inputPath);
     out << input << "\n";
     out.close();
-    string userOutputPath = cachePath + directoryPathSeparator + binaryName + "-customInvocation.userOut";
+    string userOutputPath = cachePath + directoryPathSeparator + binaryName + "-customInvocation.user.out";
 
     // Run the case with provided runs script
     // Pipe stderr to stdout so that we can monitor for TLE or RTE

--- a/src/main/runner/fastJudge.cpp
+++ b/src/main/runner/fastJudge.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
         string inputID = inputIDs[testCase];
         string inputPath = inputPaths[testCase];
         string outputPath = outputPaths[testCase];
-        string userOutputPath = cachePath + directoryPathSeparator + inputID + ".userOut";
+        string userOutputPath = cachePath + directoryPathSeparator + inputID + ".user.out";
 
         // Run the case with provided runs script
         // Pipe stderr to stdout so that we can monitor for TLE or RTE

--- a/src/main/runner/judge.ts
+++ b/src/main/runner/judge.ts
@@ -169,7 +169,7 @@ export const openCaseInfo = async (
         absPath = getCachePath(`${identifier}-customInvocation.in`);
         break;
       case 'userOutput':
-        absPath = getCachePath(`${identifier}-customInvocation.userOut`);
+        absPath = getCachePath(`${identifier}-customInvocation.user.out`);
         break;
       default:
         console.error(`Invalid infoType requested: ${infoType}`);
@@ -302,7 +302,7 @@ const judgeMultiCase = async (event: Electron.IpcMainEvent) => {
   const outputIdentifiers = (await findByExtension(data, 'out')).map(
     (outputPath) => {
       const identifier = getFileNameFromPath(trimExtension(outputPath));
-      const userOutPath = path.join(getCachePath(), `${identifier}.userOut`);
+      const userOutPath = path.join(getCachePath(), `${identifier}.user.out`);
       store.set(getDataLocationStoreKey(identifier, 'output'), outputPath);
       store.set(getDataLocationStoreKey(identifier, 'userOutput'), userOutPath);
       return identifier;

--- a/src/main/runner/judge.ts
+++ b/src/main/runner/judge.ts
@@ -1,9 +1,14 @@
 /* eslint no-await-in-loop: off, global-require: off, no-console: off, promise/always-return: off */
-import { dialog, shell } from 'electron';
+import { dialog } from 'electron';
 import Store from 'electron-store';
 import path from 'path';
 import { existsSync, readFile } from 'fs';
-import { maybeWslifyPath, spawnCommand } from '../osSpecific';
+import {
+  executeCommand,
+  maybeWslifyPath,
+  platformSpecific,
+  spawnCommand,
+} from '../osSpecific';
 import {
   getFileNameFromPath,
   findByExtension,
@@ -178,7 +183,13 @@ export const openCaseInfo = async (
     ) as string;
   }
 
-  shell.openPath(absPath);
+  // Do not call shell.openPath, it is broken on PTL
+  executeCommand(
+    platformSpecific({
+      linux: `xdg-open ${absPath}`,
+      mac: `open ${absPath}`,
+    }) as string
+  );
 };
 
 // ALl valid verdicts, and responses


### PR DESCRIPTION
We no longer use `shell.openPath` as it is broken on PTL machines.

Re-write functionality with custom implementation. Note that `xdg-open` is not an issue for Windows WSL users, as we have it listed as a dependency.